### PR TITLE
Implement game start time validation for CBB and CFB bets

### DIFF
--- a/services/betService/cbbBets.go
+++ b/services/betService/cbbBets.go
@@ -1,7 +1,6 @@
 package betService
 
 import (
-	"errors"
 	"fmt"
 	"math"
 	"perfectOddsBot/models"
@@ -23,6 +22,22 @@ var (
 	cbbPaginatedOptionsMap = make(map[string][][]discordgo.SelectMenuOption)
 	cbbPaginatedOptionsMu  sync.RWMutex
 )
+
+func parseCBBGameStartTime(date string) (time.Time, error) {
+	layouts := []string{time.RFC3339, "2006-01-02T15:04Z"}
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, date)
+		if err == nil {
+			return parsedTime, nil
+		}
+	}
+
+	return time.Time{}, fmt.Errorf("unable to parse game start time: %s", date)
+}
+
+func isFutureCBBGame(startTime time.Time) bool {
+	return startTime.After(time.Now().UTC())
+}
 
 func GetCBBPaginatedOptions(sessionID string) ([][]discordgo.SelectMenuOption, bool) {
 	cbbPaginatedOptionsMu.RLock()
@@ -84,6 +99,16 @@ func CreateCBBBet(s *discordgo.Session, i *discordgo.InteractionCreate, db *gorm
 			common.SendError(s, i, err, db)
 			return
 		}
+
+		gameStartTime, err := parseCBBGameStartTime(cbbEvent.Date)
+		if err != nil {
+			common.SendError(s, i, err, db)
+			return
+		}
+		if !isFutureCBBGame(gameStartTime) {
+			common.SendError(s, i, fmt.Errorf("cannot create a bet for a game that has already started or finished"), db)
+			return
+		}
 		homeTeam := ""
 		awayTeam := ""
 		for _, competitor := range cbbEvent.Competitions[0].Competitors {
@@ -104,16 +129,11 @@ func CreateCBBBet(s *discordgo.Session, i *discordgo.InteractionCreate, db *gorm
 		}
 
 		fmt.Println(cbbEvent.Date)
-		espnDateLayout := "2006-01-02T15:04Z"
-		utcTime, err := time.Parse(espnDateLayout, cbbEvent.Date)
-		if err != nil {
-			common.SendError(s, i, errors.New(fmt.Sprintf("err parsing time: %v", err)), db)
-			return
-		}
+		utcTime := gameStartTime
 
 		loc, err := time.LoadLocation("America/New_York")
 		if err != nil {
-			common.SendError(s, i, errors.New(fmt.Sprintf("err converting time: %v", err)), db)
+			common.SendError(s, i, fmt.Errorf("err converting time: %v", err), db)
 			return
 		}
 		t := utcTime.In(loc)
@@ -194,8 +214,6 @@ func CreateCBBBet(s *discordgo.Session, i *discordgo.InteractionCreate, db *gorm
 	}
 
 	db.Save(&dbBet)
-
-	return
 }
 
 func CreateCBBBetSelector(s *discordgo.Session, i *discordgo.InteractionCreate, db *gorm.DB) {
@@ -217,6 +235,10 @@ func CreateCBBBetSelector(s *discordgo.Session, i *discordgo.InteractionCreate, 
 
 	var selectOptions []discordgo.SelectMenuOption
 	for _, event := range events {
+		gameStartTime, timeErr := parseCBBGameStartTime(event.Date)
+		if timeErr != nil || !isFutureCBBGame(gameStartTime) {
+			continue
+		}
 		if len(event.Competitions) > 0 && event.Competitions[0].Status.Type.Name != "STATUS_FINAL" {
 			homeTeam := ""
 			awayTeam := ""
@@ -340,8 +362,6 @@ func CreateCBBBetSelector(s *discordgo.Session, i *discordgo.InteractionCreate, 
 		common.SendError(s, i, err, db)
 		return
 	}
-
-	return
 }
 
 func ShowCBBBetTypeSelection(s *discordgo.Session, i *discordgo.InteractionCreate, db *gorm.DB, betID int) error {
@@ -513,6 +533,14 @@ func CreateCBBBetFromGameID(s *discordgo.Session, i *discordgo.InteractionCreate
 		if err != nil {
 			return err
 		}
+
+		gameStartTime, err := parseCBBGameStartTime(cbbEvent.Date)
+		if err != nil {
+			return err
+		}
+		if !isFutureCBBGame(gameStartTime) {
+			return fmt.Errorf("cannot create a bet for a game that has already started or finished")
+		}
 		homeTeam := ""
 		awayTeam := ""
 		for _, competitor := range cbbEvent.Competitions[0].Competitors {
@@ -525,11 +553,7 @@ func CreateCBBBetFromGameID(s *discordgo.Session, i *discordgo.InteractionCreate
 		}
 
 		fmt.Println(cbbEvent.Date)
-		espnDateLayout := "2006-01-02T15:04Z"
-		utcTime, err := time.Parse(espnDateLayout, cbbEvent.Date)
-		if err != nil {
-			return fmt.Errorf("err parsing time: %v", err)
-		}
+		utcTime := gameStartTime
 
 		loc, err := time.LoadLocation("America/New_York")
 		if err != nil {

--- a/services/betService/cfbBets.go
+++ b/services/betService/cfbBets.go
@@ -22,6 +22,10 @@ var (
 	cfbPaginatedOptionsMu  sync.RWMutex
 )
 
+func isFutureCFBGame(startTime time.Time) bool {
+	return startTime.After(time.Now().UTC())
+}
+
 func GetCFBPaginatedOptions(sessionID string) ([][]discordgo.SelectMenuOption, bool) {
 	cfbPaginatedOptionsMu.RLock()
 	defer cfbPaginatedOptionsMu.RUnlock()
@@ -67,6 +71,10 @@ func CreateCFBBet(s *discordgo.Session, i *discordgo.InteractionCreate, db *gorm
 		cfbdBet, err := extService.GetCfbdBet(betID)
 		if err != nil {
 			common.SendError(s, i, err, db)
+			return
+		}
+		if !isFutureCFBGame(cfbdBet.StartDate) {
+			common.SendError(s, i, fmt.Errorf("cannot create a bet for a game that has already started or finished"), db)
 			return
 		}
 
@@ -168,8 +176,6 @@ func CreateCFBBet(s *discordgo.Session, i *discordgo.InteractionCreate, db *gorm
 	}
 
 	db.Save(&dbBet)
-
-	return
 }
 
 func CreateCFBBetSelector(s *discordgo.Session, i *discordgo.InteractionCreate, db *gorm.DB) {
@@ -193,7 +199,8 @@ func CreateCFBBetSelector(s *discordgo.Session, i *discordgo.InteractionCreate, 
 	var selectOptions []discordgo.SelectMenuOption
 	for _, bet := range bettingLines {
 		if (common.Contains(conferenceList, bet.HomeConference) || common.Contains(conferenceList, bet.AwayConference)) &&
-			bet.HomeScore == nil && bet.AwayScore == nil {
+			bet.HomeScore == nil && bet.AwayScore == nil &&
+			isFutureCFBGame(bet.StartDate) {
 			line, lineErr := common.PickLine(bet.Lines)
 			if lineErr != nil {
 				continue
@@ -295,8 +302,6 @@ func CreateCFBBetSelector(s *discordgo.Session, i *discordgo.InteractionCreate, 
 		common.SendError(s, i, err, db)
 		return
 	}
-
-	return
 }
 
 func ShowCFBBetTypeSelection(s *discordgo.Session, i *discordgo.InteractionCreate, db *gorm.DB, betID int) error {
@@ -439,6 +444,9 @@ func CreateCFBBetFromGameID(s *discordgo.Session, i *discordgo.InteractionCreate
 		cfbdBet, err := extService.GetCfbdBet(betID)
 		if err != nil {
 			return err
+		}
+		if !isFutureCFBGame(cfbdBet.StartDate) {
+			return fmt.Errorf("cannot create a bet for a game that has already started or finished")
 		}
 
 		line, err := common.PickLine(cfbdBet.Lines)

--- a/services/cardService/cards/handlers.go
+++ b/services/cardService/cards/handlers.go
@@ -2257,7 +2257,7 @@ func handleUnoReverse(s *discordgo.Session, db *gorm.DB, userID string, guildID 
 	var count int64
 	err := db.Table("bet_entries").
 		Joins("JOIN bets ON bets.id = bet_entries.bet_id").
-		Where("bet_entries.user_id = ? AND bets.paid = ? and bet_entries.deleted_at is null", user.ID, false).
+		Where("bet_entries.user_id = ? AND bets.active = ? AND bets.paid = ? AND bet_entries.deleted_at IS NULL", user.ID, true, false).
 		Count(&count).Error
 
 	if err != nil {

--- a/services/cardService/menus.go
+++ b/services/cardService/menus.go
@@ -249,7 +249,7 @@ func ShowBetSelectMenu(s *discordgo.Session, i *discordgo.InteractionCreate, car
 	err := db.Table("bet_entries").
 		Select("bets.id as bet_id, bets.description, bet_entries.option, bets.option1, bets.option2").
 		Joins("JOIN bets ON bets.id = bet_entries.bet_id").
-		Where("bet_entries.user_id = (SELECT id FROM users WHERE discord_id = ? AND guild_id = ?) AND bets.paid = ?", userID, guildID, false).
+		Where("bet_entries.user_id = (SELECT id FROM users WHERE discord_id = ? AND guild_id = ?) AND bets.active = ? AND bets.paid = ? AND bet_entries.deleted_at IS NULL AND bets.deleted_at IS NULL", userID, guildID, true, false).
 		Limit(25).
 		Scan(&results).Error
 

--- a/services/interactionService/cardSelection.go
+++ b/services/interactionService/cardSelection.go
@@ -188,10 +188,19 @@ func HandleCardBetSelection(s *discordgo.Session, i *discordgo.InteractionCreate
 		}
 
 		var bet models.Bet
-		if err := tx.Model(&models.Bet{}).
-			Joins("JOIN bet_entries ON bet_entries.bet_id = bets.id").
-			Where("bets.id = ? AND bets.guild_id = ? AND bets.active = ? AND bets.paid = ? AND bets.deleted_at IS NULL AND bet_entries.user_id = ? AND bet_entries.deleted_at IS NULL", targetBetID, guildID, true, false, user.ID).
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("id = ? AND guild_id = ? AND active = ? AND paid = ? AND deleted_at IS NULL", targetBetID, guildID, true, false).
 			First(&bet).Error; err != nil {
+			if err == gorm.ErrRecordNotFound {
+				return fmt.Errorf("selected bet is no longer eligible")
+			}
+			return err
+		}
+
+		var betEntry models.BetEntry
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("bet_id = ? AND user_id = ? AND deleted_at IS NULL", bet.ID, user.ID).
+			First(&betEntry).Error; err != nil {
 			if err == gorm.ErrRecordNotFound {
 				return fmt.Errorf("selected bet is no longer eligible")
 			}

--- a/services/interactionService/cardSelection.go
+++ b/services/interactionService/cardSelection.go
@@ -182,6 +182,22 @@ func HandleCardBetSelection(s *discordgo.Session, i *discordgo.InteractionCreate
 			return err
 		}
 
+		card := cardService.GetCardByID(cardID)
+		if card == nil {
+			return fmt.Errorf("card not found")
+		}
+
+		var bet models.Bet
+		if err := tx.Model(&models.Bet{}).
+			Joins("JOIN bet_entries ON bet_entries.bet_id = bets.id").
+			Where("bets.id = ? AND bets.guild_id = ? AND bets.active = ? AND bets.paid = ? AND bets.deleted_at IS NULL AND bet_entries.user_id = ? AND bet_entries.deleted_at IS NULL", targetBetID, guildID, true, false, user.ID).
+			First(&bet).Error; err != nil {
+			if err == gorm.ErrRecordNotFound {
+				return fmt.Errorf("selected bet is no longer eligible")
+			}
+			return err
+		}
+
 		inventory := models.UserInventory{
 			UserID:      user.ID,
 			GuildID:     guildID,
@@ -191,16 +207,6 @@ func HandleCardBetSelection(s *discordgo.Session, i *discordgo.InteractionCreate
 
 		if err := tx.Create(&inventory).Error; err != nil {
 			return err
-		}
-
-		card := cardService.GetCardByID(cardID)
-		if card == nil {
-			return fmt.Errorf("card not found")
-		}
-
-		var bet models.Bet
-		if err := tx.First(&bet, targetBetID).Error; err != nil {
-			return fmt.Errorf("bet not found")
 		}
 
 		guild, err := guildService.GetGuildInfo(s, tx, guildID, i.ChannelID)
@@ -223,6 +229,16 @@ func HandleCardBetSelection(s *discordgo.Session, i *discordgo.InteractionCreate
 	})
 
 	if err != nil {
+		if err.Error() == "selected bet is no longer eligible" {
+			cardService.UnmarkSelectorUsed(customID)
+			return s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseChannelMessageWithSource,
+				Data: &discordgo.InteractionResponseData{
+					Content: "That bet is no longer active or has already been paid. Please select an active unpaid bet.",
+					Flags:   discordgo.MessageFlagsEphemeral,
+				},
+			})
+		}
 		cardService.UnmarkSelectorUsed(customID)
 	}
 


### PR DESCRIPTION
- Added functions to parse game start times and check if games are in the future for both CBB and CFB betting services, enhancing bet creation logic.
- Updated CreateCBBBet and CreateCFBBet functions to utilize the new validation, ensuring bets cannot be placed on games that have already started or finished.
- Refactored time parsing logic to improve readability and maintainability across the betting services.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented bet creation on games that have already started.
  * Bets now only appear in selection lists if they are active and unpaid.

* **Improvements**
  * Uno Reverse card now only affects active bets, excluding inactive or resolved ones.
  * Added pre-checks when using cards to ensure selected bets remain eligible, with clearer ephemeral error messages and reliable selector state handling.
* **Behavior**
  * UI timing and bet scheduling now rely on validated game start times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->